### PR TITLE
video: mdss: Clean up display sysfs interface

### DIFF
--- a/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1080p-cmd.dtsi
@@ -90,7 +90,6 @@
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <255>;
 		qcom,mdss-dsi-bl-sre-level = <254>;
-		qcom,mdss-dsi-bl-cabc-max-level = <225>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "trigger_sw";
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";

--- a/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1440p-video.dtsi
+++ b/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1440p-video.dtsi
@@ -109,7 +109,6 @@
 		qcom,mdss-dsi-t-clk-pre = <0x3e>;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <255>;
-		qcom,mdss-dsi-bl-cabc-max-level = <225>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
@@ -286,7 +285,6 @@
 		qcom,mdss-dsi-t-clk-pre = <0x3e>;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <255>;
-		qcom,mdss-dsi-bl-cabc-max-level = <225>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";

--- a/arch/arm/boot/dts/msm8974-oppo/dsi-panel-truly-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/msm8974-oppo/dsi-panel-truly-1080p-cmd.dtsi
@@ -101,7 +101,6 @@
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <255>;
 		qcom,mdss-dsi-bl-sre-level = <254>;
-		qcom,mdss-dsi-bl-cabc-max-level = <225>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "trigger_sw";
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";

--- a/drivers/video/msm/mdss/mdss_dsi_panel.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel.c
@@ -74,9 +74,13 @@ static int mdss_dsi_update_cabc_level(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
     if (!pinfo->cabc_available)
         goto done;
 
-	pr_info("%s: update cabc level=%d (%d) sre=%d", __func__,
-			pinfo->cabc_mode, pinfo->cabc_active,
-			pinfo->sre_enabled);
+	pr_info("%s: update cabc level=%d  sre=%d", __func__,
+			pinfo->cabc_mode, pinfo->sre_enabled);
+
+	if (pinfo->sre_available && pinfo->sre_enabled) {
+		mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_sre_sequence);
+		goto done;
+	}
 
 	switch (pinfo->cabc_mode)
 	{
@@ -84,12 +88,7 @@ static int mdss_dsi_update_cabc_level(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 			mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_off_sequence);
 			break;
 		case 1:
-			if (pinfo->sre_available && pinfo->sre_enabled)
-				mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_sre_sequence);
-			else if (pinfo->cabc_bl_max > 0 && !pinfo->cabc_active)
-				mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_off_sequence);
-			else
-				mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_user_interface_image_sequence);
+			mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_user_interface_image_sequence);
 			break;
 		case 2:
 			mdss_dsi_panel_cmds_send(ctrl_pdata, &cabc_still_image_sequence);
@@ -1889,8 +1888,6 @@ static int mdss_panel_parse_dt(struct device_node *np,
 		"qcom,mdss-dsi-sre-ui-command", "qcom,mdss-dsi-off-command-state");
 
 	pinfo->sre_available = rc == 0 ? 1 : 0;
-
-	of_property_read_u32(np, "qcom,mdss-dsi-bl-cabc-max-level", &pinfo->cabc_bl_max);
 
 	rc = mdss_dsi_parse_dcs_cmds(np, &color_enhance_on_sequence,
 		"qcom,mdss-dsi-color-enhance-on-command", "qcom,mdss-dsi-off-command-state");

--- a/drivers/video/msm/mdss/mdss_panel.h
+++ b/drivers/video/msm/mdss/mdss_panel.h
@@ -375,8 +375,6 @@ struct mdss_panel_info {
 #ifdef CONFIG_MACH_OPPO
 	int cabc_available;
 	int cabc_mode;
-	int cabc_bl_max;
-	bool cabc_active;
 
 	int gamma_index;
 	int gamma_count;


### PR DESCRIPTION
- Clean up dead code which was moved to the framework
- Fix issue with SRE at max brightness

Change-Id: Ibec05238cc3dc3ad048e96917d70705d64648ecc
